### PR TITLE
WIP: Safer clist

### DIFF
--- a/src/clist.rs
+++ b/src/clist.rs
@@ -53,8 +53,6 @@ pub fn clist_new() -> *mut clist {
 pub unsafe fn clist_free(mut lst: *mut clist) {
     Box::from_raw(lst);
 }
-/* Some of the following routines can be implemented as macros to
-be faster. If you don't want it, define NO_MACROS */
 /* Inserts this data pointer before the element pointed by the iterator */
 pub unsafe fn clist_insert_before(
     mut lst: *mut clist,

--- a/src/clist.rs
+++ b/src/clist.rs
@@ -126,22 +126,6 @@ pub unsafe fn clist_foreach(
     }
 }
 
-pub unsafe fn clist_concat(mut dest: *mut clist, mut src: *mut clist) {
-    if !(*src).first.is_null() {
-        if (*dest).last.is_null() {
-            (*dest).first = (*src).first;
-            (*dest).last = (*src).last
-        } else {
-            (*(*dest).last).next = (*src).first;
-            (*(*src).first).previous = (*dest).last;
-            (*dest).last = (*src).last
-        }
-    }
-    (*dest).count += (*src).count;
-    (*src).first = 0 as *mut clistcell;
-    (*src).last = (*src).first;
-}
-
 pub unsafe fn clist_nth_data(mut lst: *mut clist, mut indx: libc::c_int) -> *mut libc::c_void {
     let mut cur: *mut clistiter = 0 as *mut clistiter;
     cur = internal_clist_nth(lst, indx);

--- a/src/clist.rs
+++ b/src/clist.rs
@@ -10,7 +10,7 @@ pub struct clistcell {
     pub next: *mut clistcell,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct clist {
     pub first: *mut clistcell,

--- a/src/clist.rs
+++ b/src/clist.rs
@@ -53,43 +53,6 @@ pub fn clist_new() -> *mut clist {
 pub unsafe fn clist_free(mut lst: *mut clist) {
     Box::from_raw(lst);
 }
-/* Inserts this data pointer before the element pointed by the iterator */
-pub unsafe fn clist_insert_before(
-    mut lst: *mut clist,
-    mut iter: *mut clistiter,
-    mut data: *mut libc::c_void,
-) -> libc::c_int {
-    let mut c: *mut clistcell = 0 as *mut clistcell;
-    c = malloc(::std::mem::size_of::<clistcell>() as libc::size_t) as *mut clistcell;
-    if c.is_null() {
-        return -1i32;
-    }
-    (*c).data = data;
-    (*lst).count += 1;
-    if (*lst).first == (*lst).last && (*lst).last.is_null() {
-        (*c).next = 0 as *mut clistcell;
-        (*c).previous = (*c).next;
-        (*lst).last = c;
-        (*lst).first = (*lst).last;
-        return 0i32;
-    }
-    if iter.is_null() {
-        (*c).previous = (*lst).last;
-        (*(*c).previous).next = c;
-        (*c).next = 0 as *mut clistcell;
-        (*lst).last = c;
-        return 0i32;
-    }
-    (*c).previous = (*iter).previous;
-    (*c).next = iter;
-    (*(*c).next).previous = c;
-    if !(*c).previous.is_null() {
-        (*(*c).previous).next = c
-    } else {
-        (*lst).first = c
-    }
-    return 0i32;
-}
 /* Inserts this data pointer after the element pointed by the iterator */
 pub unsafe fn clist_insert_after(
     mut lst: *mut clist,


### PR DESCRIPTION
Plan is to reimplement it on top of [`LinkedList`](https://doc.rust-lang.org/std/collections/struct.LinkedList.html). Not sure if it is possible, because [`insert_next`](https://doc.rust-lang.org/std/collections/linked_list/struct.IterMut.html#method.insert_next) is a nightly feature and there is no `insert_prev`.