### PR TITLE
[wip] add null-pointer check before calling strncasecmp()

### DIFF
--- a/src/mailimf.rs
+++ b/src/mailimf.rs
@@ -1513,6 +1513,11 @@ pub unsafe fn mailimf_token_case_insensitive_len_parse(
     {
         return MAILIMF_ERROR_PARSE as libc::c_int;
     }
+
+    if token.is_null() || message.is_null() || strlen(message)>=cur_token {
+        return MAILIMF_ERROR_PARSE as libc::c_int;
+    }
+
     if strncasecmp(message.offset(cur_token as isize), token, token_length) == 0i32 {
         cur_token = (cur_token as libc::size_t).wrapping_add(token_length) as size_t as size_t;
         *indx = cur_token;


### PR DESCRIPTION
i got a crash on ios that pointed to a crash in strcmp() called by strncasecmp() at https://github.com/dignifiedquire/mmime/blob/master/src/mailimf.rs#L1516

if have no concrete idea why this can happen, however, adding a check for NULL-pointers may help.
(strlen() has undocumented behavior on passing NULL, so it may be that it crashed on ios but not on linux, where i did not manage to reproduce the error)

btw. for some reason it makes the app frozen, not going away.

if needed, here is a screenshot of the process view in xcode:

<img width="1440" alt="Screen Shot 2019-09-14 at 23 44 09" src="https://user-images.githubusercontent.com/9800740/64914327-677acc80-d74f-11e9-9459-5edad43ff42d.png">